### PR TITLE
Fixed inline style not loading when user is logged out

### DIFF
--- a/includes/class-rp-frontend-scripts.php
+++ b/includes/class-rp-frontend-scripts.php
@@ -165,29 +165,29 @@ class RP_Frontend_Scripts {
 		// Load styles
 		return "
 		.restaurantpress .rp-chef-badge {
-			background: {$primary_color} !important;
+			background: ".esc_attr( $primary_color )." !important;
 		}
 
 		.restaurantpress .rp-chef-badge:before,
 		.restaurantpress .rp-chef-badge:after {
-			border-top-color: {$primary_color} !important;
+			border-top-color: ".esc_attr( $primary_color )." !important;
 		}
 
 		.restaurantpress .rp-price {
-			background: {$primary_color} !important;
+			background: ".esc_attr( $primary_color )." !important;
 		}
 
 		.restaurantpress .rp-price:before {
-			border-right-color: {$primary_color} !important;
+			border-right-color: ".esc_attr( $primary_color )." !important;
 		}
 
 		.restaurantpress .rp-content-wrapper {
-			border-bottom-color: {$primary_color} !important;
+			border-bottom-color: ".esc_attr( $primary_color)." !important;
 		}
 
 		.restaurantpress .image-magnify span:hover {
-			background: {$primary_color} !important;
-			border-color: {$primary_color} !important;
+			background: ".esc_attr( $primary_color )." !important;
+			border-color: ".esc_attr( $primary_color )." !important;
 		}
 		";
 

--- a/includes/class-rp-frontend-scripts.php
+++ b/includes/class-rp-frontend-scripts.php
@@ -150,10 +150,8 @@ class RP_Frontend_Scripts {
 			}
 
 			// Inline Styles
-			if ( current_user_can( 'manage_restaurantpress' ) ) {
-				$inline_styles = self::create_primary_styles();
-				wp_add_inline_style( 'restaurantpress-general', $inline_styles );
-			}
+			$inline_styles = self::create_primary_styles();
+			wp_add_inline_style( 'restaurantpress-general', $inline_styles );
 		}
 	}
 


### PR DESCRIPTION
Inline styles were only being loaded for logged in users with `manage_restaurantpress` capability. Hence Primary color option changes via the settings were not being reflected on the frontend when users were logged out.
Issue has been reported here https://wordpress.org/support/topic/restaurantpress-menu-price-color?replies=1
