### PR TITLE
PHPCS - Check for translatable strings placeholders

### DIFF
--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -64,10 +64,6 @@
 		<exclude name="WordPress.VIP.SuperGlobalInputUsage.AccessDetected" />
 		<exclude name="WordPress.Variables.GlobalVariables.OverrideProhibited" />
 		<exclude name="WordPress.WP.EnqueuedResources.NonEnqueuedScript" />
-		<exclude name="WordPress.WP.I18n.MissingSingularPlaceholder" />
-		<exclude name="WordPress.WP.I18n.MismatchedPlaceholders" />
-		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralPlural" />
-		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralText" />
 		<exclude name="WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet" />
 		<exclude name="WordPress.WP.PreparedSQL.NotPrepared" />
 		<exclude name="WordPress.XSS.EscapeOutput.OutputNotEscaped" />


### PR DESCRIPTION
This also ensure that each placeholder have a properly description.

This also ensure that each placeholder have a properly description.

Example of single placeholder:
```
/* translators: %s: post type */
sprintf( __( 'The %s has already been deleted.', 'restaurantpress' ), $this->post_type );
```
Example of multiples placeholders:
```
/* translators: 1: top seller food title 2: top seller quantity */
printf(
	__( '%1$s top seller this month (sold %2$d)', 'restaurantpress' ),
	'<strong>' . get_the_title( $top_seller->food_id ) . '</strong>',
	$top_seller->qty
);
```