### PR TITLE
Deprecated hook handling

### DIFF
--- a/includes/abstracts/abstract-rp-deprecated-hooks.php
+++ b/includes/abstracts/abstract-rp-deprecated-hooks.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * RP_Deprecated_Hooks class maps old actions and filters to new ones. This is the base class for handling those deprecated hooks.
+ *
+ * Based on the WCS_Hook_Deprecator class by Prospress.
+ *
+ * @class    RP_Deprecated_Hooks
+ * @version  1.5.0
+ * @package  RestaurantPress/Abstracts
+ * @category Abstract Class
+ * @author   WPEverest
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * RP_Deprecated_Hooks class.
+ */
+abstract class RP_Deprecated_Hooks {
+
+	/**
+	 * Array of deprecated hooks we need to handle.
+	 *
+	 * @var array
+	 */
+	protected $deprecated_hooks = array();
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$new_hooks = array_keys( $this->deprecated_hooks );
+		array_walk( $new_hooks, array( $this, 'hook_in' ) );
+	}
+
+	/**
+	 * Hook into the new hook so we can handle deprecated hooks once fired.
+	 *
+	 * @param string $hook_name
+	 */
+	abstract function hook_in( $hook_name );
+
+	/**
+	 * Get old hooks to map to new hook.
+	 *
+	 * @param  string $new_hook
+	 * @return array
+	 */
+	public function get_old_hooks( $new_hook ) {
+		$old_hooks = isset( $this->deprecated_hooks[ $new_hook ] ) ? $this->deprecated_hooks[ $new_hook ] : array();
+		$old_hooks = is_array( $old_hooks ) ? $old_hooks : array( $old_hooks );
+
+		return $old_hooks;
+	}
+
+	/**
+	 * If the hook is Deprecated, call the old hooks here.
+	 */
+	public function maybe_handle_deprecated_hook() {
+		$new_hook          = current_filter();
+		$old_hooks         = $this->get_old_hooks( $new_hook );
+		$new_callback_args = func_get_args();
+		$return_value      = $new_callback_args[0];
+
+		foreach ( $old_hooks as $old_hook ) {
+			$return_value = $this->handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value );
+		}
+
+		return $return_value;
+	}
+
+	/**
+	 * If the old hook is in-use, trigger it.
+	 *
+	 * @param  string $new_hook
+	 * @param  string $old_hook
+	 * @param  array  $new_callback_args
+	 * @param  mixed  $return_value
+	 * @return mixed
+	 */
+	abstract function handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value );
+
+	/**
+	 * Display a deprecated notice for old hooks.
+	 *
+	 * @param string $old_hook
+	 * @param string $new_hook
+	 */
+	protected function display_notice( $old_hook, $new_hook ) {
+		rp_deprecated_function( sprintf( 'The "%s" hook uses out of date data structures and', esc_html( $old_hook ) ), RP_VERSION, esc_html( $new_hook ) );
+	}
+
+	/**
+	 * Fire off a legacy hook with it's args.
+	 *
+	 * @param  string $old_hook
+	 * @param  array  $new_callback_args
+	 * @return mixed
+	 */
+	abstract protected function trigger_hook( $old_hook, $new_callback_args );
+}

--- a/includes/abstracts/abstract-rp-session.php
+++ b/includes/abstracts/abstract-rp-session.php
@@ -13,6 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * RP_Session class.
+ */
 abstract class RP_Session {
 
 	/** @var int $_customer_id */

--- a/includes/class-restaurantpress.php
+++ b/includes/class-restaurantpress.php
@@ -49,6 +49,13 @@ final class RestaurantPress {
 	public $food_factory = null;
 
 	/**
+	 * Array of deprecated hook handlers.
+	 *
+	 * @var array of RP_Deprecated_Hooks
+	 */
+	public $deprecated_hook_handlers = array();
+
+	/**
 	 * Main RestaurantPress Instance.
 	 *
 	 * Ensure only one instance of RestaurantPress is loaded or can be loaded.
@@ -161,6 +168,7 @@ final class RestaurantPress {
 		 * Abstract classes.
 		 */
 		include_once( RP_ABSPATH . 'includes/abstracts/abstract-rp-food.php' ); // Foods.
+		include_once( RP_ABSPATH . 'includes/abstracts/abstract-rp-deprecated-hooks.php' );
 		include_once( RP_ABSPATH . 'includes/abstracts/abstract-rp-session.php' );
 
 		/**
@@ -173,6 +181,8 @@ final class RestaurantPress {
 		include_once( RP_ABSPATH . 'includes/class-rp-ajax.php' );
 		include_once( RP_ABSPATH . 'includes/class-rp-food-factory.php' ); // Food factory.
 		include_once( RP_ABSPATH . 'includes/class-rp-cache-helper.php' ); // Cache Helper.
+		include_once( RP_ABSPATH . 'includes/class-rp-deprecated-action-hooks.php' );
+		include_once( RP_ABSPATH . 'includes/class-rp-deprecated-filter-hooks.php' );
 
 		if ( $this->is_request( 'admin' ) ) {
 			include_once( RP_ABSPATH . 'includes/admin/class-rp-admin.php' );
@@ -216,7 +226,9 @@ final class RestaurantPress {
 		$this->load_plugin_textdomain();
 
 		// Load class instances.
-		$this->food_factory = new RP_Food_Factory(); // Food Factory to create new food instances.
+		$this->food_factory                        = new RP_Food_Factory(); // Food Factory to create new food instances.
+		$this->deprecated_hook_handlers['actions'] = new RP_Deprecated_Action_Hooks();
+		$this->deprecated_hook_handlers['filters'] = new RP_Deprecated_Filter_Hooks();
 
 		// Session class, handles session data for users - can be overwritten if custom handler is needed.
 		if ( $this->is_request( 'frontend' ) || $this->is_request( 'cron' ) ) {

--- a/includes/class-rp-deprecated-action-hooks.php
+++ b/includes/class-rp-deprecated-action-hooks.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Handles deprecation notices and triggering of legacy action hooks.
+ *
+ * @class    RP_Deprecated_Action_Hooks
+ * @version  1.5.0
+ * @package  RestaurantPress/Classes
+ * @category Class
+ * @author   WPEverest
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * RP_Deprecated_Action_Hooks Class.
+ */
+class RP_Deprecated_Action_Hooks extends RP_Deprecated_Hooks {
+
+	/**
+	 * Array of deprecated hooks we need to handle.
+	 * Format of 'new' => 'old'.
+	 *
+	 * @var array
+	 */
+	protected $deprecated_hooks = array();
+
+	/**
+	 * Hook into the new hook so we can handle deprecated hooks once fired.
+	 * @param string $hook_name
+	 */
+	public function hook_in( $hook_name ) {
+		add_action( $hook_name, array( $this, 'maybe_handle_deprecated_hook' ), -1000, 8 );
+	}
+
+	/**
+	 * If the old hook is in-use, trigger it.
+	 *
+	 * @param  string $new_hook
+	 * @param  string $old_hook
+	 * @param  array  $new_callback_args
+	 * @param  mixed  $return_value
+	 * @return mixed
+	 */
+	public function handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value ) {
+		if ( has_action( $old_hook ) ) {
+			$this->display_notice( $old_hook, $new_hook );
+			$return_value = $this->trigger_hook( $old_hook, $new_callback_args );
+		}
+		return $return_value;
+	}
+
+	/**
+	 * Fire off a legacy hook with it's args.
+	 *
+	 * @param  string $old_hook
+	 * @param  array  $new_callback_args
+	 * @return mixed
+	 */
+	protected function trigger_hook( $old_hook, $new_callback_args ) {
+		do_action_ref_array( $old_hook, $new_callback_args );
+	}
+}

--- a/includes/class-rp-deprecated-filter-hooks.php
+++ b/includes/class-rp-deprecated-filter-hooks.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Handles deprecation notices and triggering of legacy filter hooks.
+ *
+ * @class    RP_Deprecated_Filter_Hooks
+ * @version  1.5.0
+ * @package  RestaurantPress/Classes
+ * @category Class
+ * @author   WPEverest
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * RP_Deprecated_Filter_Hooks Class.
+ */
+class RP_Deprecated_Filter_Hooks extends RP_Deprecated_Hooks {
+
+	/**
+	 * Array of deprecated hooks we need to handle.
+	 * Format of 'new' => 'old'.
+	 *
+	 * @var array
+	 */
+	protected $deprecated_hooks = array();
+
+	/**
+	 * Hook into the new hook so we can handle deprecated hooks once fired.
+	 * @param string $hook_name
+	 */
+	public function hook_in( $hook_name ) {
+		add_filter( $hook_name, array( $this, 'maybe_handle_deprecated_hook' ), -1000, 8 );
+	}
+
+	/**
+	 * If the old hook is in-use, trigger it.
+	 *
+	 * @param  string $new_hook
+	 * @param  string $old_hook
+	 * @param  array  $new_callback_args
+	 * @param  mixed  $return_value
+	 * @return mixed
+	 */
+	public function handle_deprecated_hook( $new_hook, $old_hook, $new_callback_args, $return_value ) {
+		if ( has_filter( $old_hook ) ) {
+			$this->display_notice( $old_hook, $new_hook );
+			$return_value = $this->trigger_hook( $old_hook, $new_callback_args );
+		}
+		return $return_value;
+	}
+
+	/**
+	 * Fire off a legacy hook with it's args.
+	 *
+	 * @param  string $old_hook
+	 * @param  array  $new_callback_args
+	 * @return mixed
+	 */
+	protected function trigger_hook( $old_hook, $new_callback_args ) {
+		return apply_filters_ref_array( $old_hook, $new_callback_args );
+	}
+}


### PR DESCRIPTION
Adds deprecation handling based on the `WCS_Hook_Deprecator` class by Prospress's work to deprecate actions and filters.