### PR TITLE
Demonstrate how to add a new RestaurantPress integration

### DIFF
--- a/includes/abstracts/abstract-rp-integration.php
+++ b/includes/abstracts/abstract-rp-integration.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Abstract Integration Class
+ *
+ * Extended by individual integrations to offer additional functionality.
+ *
+ * @class    RP_Integration
+ * @extends  RP_Settings_API
+ * @version  1.0.0
+ * @package  RestaurantPress/Abstracts
+ * @category Abstract Class
+ * @author   WPEverest
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * RP_Integration class.
+ */
+abstract class RP_Integration extends RP_Settings_API {
+
+	/**
+	 * yes or no based on whether the integration is enabled.
+	 *
+	 * @var string
+	 */
+	public $enabled = 'yes';
+
+	/**
+	 * Integration title.
+	 *
+	 * @var string
+	 */
+	public $method_title = '';
+
+	/**
+	 * Integration description.
+	 *
+	 * @var string
+	 */
+	public $method_description = '';
+
+	/**
+	 * Return the title for admin screens.
+	 *
+	 * @return string
+	 */
+	public function get_method_title() {
+		return apply_filters( 'restaurantpress_integration_title', $this->method_title, $this );
+	}
+
+	/**
+	 * Return the description for admin screens.
+	 * @return string
+	 */
+	public function get_method_description() {
+		return apply_filters( 'restaurantpress_integration_description', $this->method_description, $this );
+	}
+
+	/**
+	 * Output the gateway settings screen.
+	 */
+	public function admin_options() {
+		echo '<h2>' . esc_html( $this->get_method_title() ) . '</h2>';
+		echo wp_kses_post( wpautop( $this->get_method_description() ) );
+		echo '<div><input type="hidden" name="section" value="' . esc_attr( $this->id ) . '" /></div>';
+		parent::admin_options();
+	}
+
+	/**
+	 * Init settings for integrations.
+	 */
+	public function init_settings() {
+		parent::init_settings();
+		$this->enabled  = ! empty( $this->settings['enabled'] ) && 'yes' === $this->settings['enabled'] ? 'yes' : 'no';
+	}
+}

--- a/includes/abstracts/abstract-rp-integration.php
+++ b/includes/abstracts/abstract-rp-integration.php
@@ -6,7 +6,7 @@
  *
  * @class    RP_Integration
  * @extends  RP_Settings_API
- * @version  1.0.0
+ * @version  1.5.1
  * @package  RestaurantPress/Abstracts
  * @category Abstract Class
  * @author   WPEverest

--- a/includes/admin/class-rp-admin-settings.php
+++ b/includes/admin/class-rp-admin-settings.php
@@ -51,6 +51,7 @@ class RP_Admin_Settings {
 			include_once( dirname( __FILE__ ) . '/settings/class-rp-settings-page.php' );
 
 			$settings[] = include( 'settings/class-rp-settings-general.php' );
+			$settings[] = include( 'settings/class-rp-settings-integrations.php' );
 
 			self::$settings = apply_filters( 'restaurantpress_get_settings_pages', $settings );
 		}

--- a/includes/admin/settings/class-rp-settings-integrations.php
+++ b/includes/admin/settings/class-rp-settings-integrations.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * RestaurantPress Integration Settings
+ *
+ * @class    RP_Settings_Integrations
+ * @version  1.5.1
+ * @package  RestaurantPress/Admin
+ * @category Admin
+ * @author   WPEverest
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! class_exists( 'RP_Settings_Integrations', false ) ) :
+
+/**
+ * RP_Settings_Integrations Class.
+ */
+class RP_Settings_Integrations extends RP_Settings_Page {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->id    = 'integration';
+		$this->label = __( 'Integration', 'restaurantpress' );
+
+		if ( isset( RP()->integrations ) && RP()->integrations->get_integrations() ) {
+			parent::__construct();
+		}
+	}
+
+	/**
+	 * Get sections.
+	 *
+	 * @return array
+	 */
+	public function get_sections() {
+		global $current_section;
+
+		$sections = array();
+
+		if ( ! defined( 'RP_INSTALLING' ) ) {
+			$integrations = RP()->integrations->get_integrations();
+
+			if ( ! $current_section && ! empty( $integrations ) ) {
+				$current_section = current( $integrations )->id;
+			}
+
+			if ( sizeof( $integrations ) > 1 ) {
+				foreach ( $integrations as $integration ) {
+					$title = empty( $integration->method_title ) ? ucfirst( $integration->id ) : $integration->method_title;
+					$sections[ strtolower( $integration->id ) ] = esc_html( $title );
+				}
+			}
+		}
+
+		return apply_filters( 'restaurantpress_get_sections_' . $this->id, $sections );
+	}
+
+	/**
+	 * Output the settings.
+	 */
+	public function output() {
+		global $current_section;
+
+		$integrations = RP()->integrations->get_integrations();
+
+		if ( isset( $integrations[ $current_section ] ) ) {
+			$integrations[ $current_section ]->admin_options();
+		}
+	}
+}
+
+endif;
+
+return new RP_Settings_Integrations();

--- a/includes/class-restaurantpress.php
+++ b/includes/class-restaurantpress.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Main RestaurantPress Class.
  *
  * @class   RestaurantPress
- * @version 1.3.2
+ * @version 1.5.1
  */
 final class RestaurantPress {
 
@@ -47,6 +47,13 @@ final class RestaurantPress {
 	 * @var RP_Food_Factory
 	 */
 	public $food_factory = null;
+
+	/**
+	 * Integrations instance.
+	 *
+	 * @var RP_Integrations
+	 */
+	public $integrations = null;
 
 	/**
 	 * Array of deprecated hook handlers.
@@ -169,6 +176,7 @@ final class RestaurantPress {
 		 */
 		include_once( RP_ABSPATH . 'includes/abstracts/abstract-rp-food.php' ); // Foods.
 		include_once( RP_ABSPATH . 'includes/abstracts/abstract-rp-settings-api.php' ); // Settings API (for mailer, and integrations).
+		include_once( RP_ABSPATH . 'includes/abstracts/abstract-rp-integration.php' ); // An integration with a service.
 		include_once( RP_ABSPATH . 'includes/abstracts/abstract-rp-deprecated-hooks.php' );
 		include_once( RP_ABSPATH . 'includes/abstracts/abstract-rp-session.php' );
 
@@ -183,6 +191,7 @@ final class RestaurantPress {
 		include_once( RP_ABSPATH . 'includes/class-rp-ajax.php' );
 		include_once( RP_ABSPATH . 'includes/class-rp-data-exception.php' );
 		include_once( RP_ABSPATH . 'includes/class-rp-food-factory.php' ); // Food factory.
+		include_once( RP_ABSPATH . 'includes/class-rp-integrations.php' ); // Loads integrations.
 		include_once( RP_ABSPATH . 'includes/class-rp-cache-helper.php' ); // Cache Helper.
 		include_once( RP_ABSPATH . 'includes/class-rp-deprecated-action-hooks.php' );
 		include_once( RP_ABSPATH . 'includes/class-rp-deprecated-filter-hooks.php' );
@@ -230,6 +239,7 @@ final class RestaurantPress {
 
 		// Load class instances.
 		$this->food_factory                        = new RP_Food_Factory(); // Food Factory to create new food instances.
+		$this->integrations                        = new RP_Integrations(); // Integrations class.
 		$this->deprecated_hook_handlers['actions'] = new RP_Deprecated_Action_Hooks();
 		$this->deprecated_hook_handlers['filters'] = new RP_Deprecated_Filter_Hooks();
 

--- a/includes/class-rp-integrations.php
+++ b/includes/class-rp-integrations.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * RestaurantPress Integrations class
+ *
+ * Loads Integrations into RestaurantPress.
+ *
+ * @class    RP_Integrations
+ * @version  1.5.1
+ * @package  RestaurantPress/Classes/Integrations
+ * @category Class
+ * @author   WPEverest
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * RP_Integrations Class.
+ */
+class RP_Integrations {
+
+	/**
+	 * Array of integrations.
+	 *
+	 * @var array
+	 */
+	public $integrations = array();
+
+	/**
+	 * Initialize integrations.
+	 */
+	public function __construct() {
+
+		do_action( 'restaurantpress_integrations_init' );
+
+		$load_integrations = apply_filters( 'restaurantpress_integrations', array() );
+
+		// Load integration classes.
+		foreach ( $load_integrations as $integration ) {
+
+			$load_integration = new $integration();
+
+			$this->integrations[ $load_integration->id ] = $load_integration;
+		}
+	}
+
+	/**
+	 * Return loaded integrations.
+	 *
+	 * @return array
+	 */
+	public function get_integrations() {
+		return $this->integrations;
+	}
+}


### PR DESCRIPTION
RestaurantPress provides a facility for registering app integrations. If integrations are registered, an Integrations tab is made available under the RestaurantPress > Settings screen.

Sample integration plugin: [restaurantpress-integration-demo.zip](https://github.com/wpeverest/restaurantpress/files/1428609/restaurantpress-integration-demo.zip)
