### PR TITLE
Move custom image sizes registration to the init hook

### DIFF
--- a/includes/class-restaurantpress.php
+++ b/includes/class-restaurantpress.php
@@ -121,6 +121,7 @@ final class RestaurantPress {
 		add_action( 'init', array( $this, 'init' ), 0 );
 		add_action( 'init', array( 'RP_Shortcodes', 'init' ) );
 		add_action( 'init', array( $this, 'wpdb_table_fix' ), 0 );
+		add_action( 'init', array( $this, 'add_image_sizes' ) );
 		add_action( 'switch_blog', array( $this, 'wpdb_table_fix' ), 0 );
 	}
 
@@ -320,7 +321,6 @@ final class RestaurantPress {
 	 */
 	public function setup_environment() {
 		$this->add_thumbnail_support();
-		$this->add_image_sizes();
 	}
 
 	/**
@@ -349,7 +349,7 @@ final class RestaurantPress {
 	 *
 	 * @since 1.7
 	 */
-	private function add_image_sizes() {
+	public function add_image_sizes() {
 		$thumbnail = rp_get_image_size( 'thumbnail' );
 		$single    = rp_get_image_size( 'single' );
 		$food_grid = rp_get_image_size( 'food_grid' );


### PR DESCRIPTION
The `after_setup_theme hook` runs before the `add_theme_support()` declaration is processed, so the values returned by `rp_get_image_size()` at the time we currently register the custom sizes are always the default set by RestaurantPress.

WordPress gets confused and doesn't output a `srcset` for any of the custom images.

This PR moves the custom image registration to the `init` hook.