### PR TITLE
Disable Gutenberg for food_menu

### DIFF
--- a/includes/class-rp-post-types.php
+++ b/includes/class-rp-post-types.php
@@ -28,6 +28,8 @@ class RP_Post_Types {
 		add_filter( 'rest_api_allowed_post_types', array( __CLASS__, 'rest_api_allowed_post_types' ) );
 		add_action( 'restaurantpress_after_register_post_type', array( __CLASS__, 'maybe_flush_rewrite_rules' ) );
 		add_action( 'restaurantpress_flush_rewrite_rules', array( __CLASS__, 'flush_rewrite_rules' ) );
+		add_filter( 'gutenberg_can_edit_post_type', array( __CLASS__, 'gutenberg_can_edit_post_type' ), 10, 2 );
+		add_filter( 'use_block_editor_for_post_type', array( __CLASS__, 'gutenberg_can_edit_post_type' ), 10, 2 );
 	}
 
 	/**
@@ -271,6 +273,17 @@ class RP_Post_Types {
 	 */
 	public static function flush_rewrite_rules() {
 		flush_rewrite_rules();
+	}
+
+	/**
+	 * Disable Gutenberg for food_menu.
+	 *
+	 * @param bool   $can_edit Whether the post type can be edited or not.
+	 * @param string $post_type The post type being checked.
+	 * @return bool
+	 */
+	public static function gutenberg_can_edit_post_type( $can_edit, $post_type ) {
+		return 'food_menu' === $post_type ? false : $can_edit;
 	}
 }
 


### PR DESCRIPTION
This will disable Gutenberg in `food_menu` Post type. Thus better compatibility with RestaurantPress WooCommece Integration :)