### PR TITLE
Chore - Version Bump to 1.8.1 for WordPress 5.4 Compatibility

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.8.1 - 10/04/2019 =
+* Version Bump - Tested upto WordPress 5.4.
+
 = 1.8.0 - 17/11/2018 =
 * Feature - Introduced RestaurantPress Group block.
 * Tweak - Disable Gutenberg for food_menu post type.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,7 @@
 == Changelog ==
 
 = 1.8.1 - 10/04/2019 =
-* Version Bump - Tested upto WordPress 5.4.
+* Tested upto WordPress 5.4.
 
 = 1.8.0 - 17/11/2018 =
 * Feature - Introduced RestaurantPress Group block.

--- a/includes/class-restaurantpress.php
+++ b/includes/class-restaurantpress.php
@@ -20,7 +20,7 @@ final class RestaurantPress {
 	 *
 	 * @var string
 	 */
-	public $version = '1.8.0';
+	public $version = '1.8.1';
 
 	/**
 	 * The single instance of the class.
@@ -288,8 +288,8 @@ final class RestaurantPress {
 		// Classes/actions loaded for the frontend and for ajax requests.
 		if ( $this->is_request( 'frontend' ) ) {
 			// Session class, handles session data for users - can be overwritten if custom handler is needed.
-			$session_class  = apply_filters( 'restaurantpress_session_handler', 'RP_Session_Handler' );
-			$this->session  = new $session_class();
+			$session_class = apply_filters( 'restaurantpress_session_handler', 'RP_Session_Handler' );
+			$this->session = new $session_class();
 			$this->session->init();
 		}
 

--- a/languages/restaurantpress.pot
+++ b/languages/restaurantpress.pot
@@ -1,8 +1,8 @@
-# Copyright (C) 2018 WPEverest
+# Copyright (C) 2020 WPEverest
 # This file is distributed under the same license as the RestaurantPress package.
 msgid ""
 msgstr ""
-"Project-Id-Version: RestaurantPress 1.8.0\n"
+"Project-Id-Version: RestaurantPress 1.8.1\n"
 "Report-Msgid-Bugs-To: https://github.com/wpeverest/restaurantpress/issues\n"
 "POT-Creation-Date: 2018-12-14 05:55:50+00:00\n"
 "MIME-Version: 1.0\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restaurantpress",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restaurantpress",
   "title": "RestaurantPress",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "homepage": "https://wpeverest.com/restaurantpress",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -67,7 +67,7 @@ Yes you can! Join in on our [GitHub repository](https://github.com/wpeverest/res
 == Changelog ==
 
 = 1.8.1 - 10/04/2019 =
-* Version Bump - Tested upto WordPress 5.4.
+* Tested upto WordPress 5.4.
 
 = 1.8.0 - 17/11/2018 =
 * Feature - Introduced RestaurantPress Group block.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: WPEverest, shivapoudel
 Tags: restaurant, appetizer, food, cafe, menu, dining, drink
 Requires at least: 4.7
-Tested up to: 5.0
-Stable tag: 1.8.0
+Tested up to: 5.4
+Stable tag: 1.8.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -66,6 +66,9 @@ Yes you can! Join in on our [GitHub repository](https://github.com/wpeverest/res
 
 == Changelog ==
 
+= 1.8.1 - 10/04/2019 =
+* Version Bump - Tested upto WordPress 5.4.
+
 = 1.8.0 - 17/11/2018 =
 * Feature - Introduced RestaurantPress Group block.
 * Tweak - Disable Gutenberg for food_menu post type.
@@ -77,3 +80,6 @@ Yes you can! Join in on our [GitHub repository](https://github.com/wpeverest/res
 
 = 1.8.0 =
 1.8.0 is a minor update. Make a full site backup, update your theme and extensions, and ensure they are compatible before upgrading.
+
+= 1.8.1 =
+This update makes sure the plugin is WordPress 5.4 compatible.

--- a/restaurantpress.php
+++ b/restaurantpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: RestaurantPress
  * Plugin URI: https://wpeverest.com/wordpress-plugins/restaurantpress/
  * Description: Allows you to create awesome restaurant menus for restaurants, bars, and cafes in no time. Smartly :)
- * Version: 1.8.0
+ * Version: 1.8.1
  * Author: WPEverest
  * Author URI: https://wpeverest.com
  * Text Domain: restaurantpress


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [User Registration Contributing guideline](https://github.com/wpeverest/restaurantpress/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Version bump to 1.8.1 to confirm WordPress 5.4 Compatibility.

### How to test the changes in this Pull Request:

1. Navigate to the form builder.
2. Try down-scaling a 3 columns row to 2 columns.
3. Observe that the 3rd (lost column) has its field elements redistributed.

### Types of changes:

* [x] Version Bump
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Enhancement (modification of the currently available functionality)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Mark completed items with an [x] -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
* [x] Have you updated the documentation accordingly?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Chore - Version Bump to 1.8.1 for WordPress 5.4 Compatibility